### PR TITLE
added rate limiting

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,11 @@
+global_requests_per_second: 100
 backends:
   - url: http://server1:80
+    backend_requests_per_second: 50
   - url: http://server2:80
+    backend_requests_per_second: 100
   - url: http://server3:80
+    backend_requests_per_second: 75
 
 health_check_interval: 10s   # Interval for health checks (e.g., 10s, 1m)
 max_latency: 100ms           # Maximum allowable latency

--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,6 @@ module loadbalancer
 go 1.22.4
 
 require (
+	golang.org/x/time v0.7.0
 	gopkg.in/yaml.v2 v2.4.0
 )


### PR DESCRIPTION
**`Global Rate Limit:`**

A new configuration option global_requests_per_second has been added in config.yaml. This defines the default global rate limit (requests per second) that applies to all backends unless overridden at the backend level.

**`Backend-Specific Rate Limits:`**

Each backend can now specify its own rate limit using the backend_requests_per_second field in config.yaml. If a backend-specific rate limit is not defined, the global rate limit will be applied by default.

**`Rate Limiting Logic:`**

Implemented using the golang.org/x/time/rate package.
The rate limiter is applied per backend, ensuring that requests exceeding the defined rate limit will receive an HTTP 429 Too Many Requests respon